### PR TITLE
Fix GUI DRC and add DUMMY option

### DIFF
--- a/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/main.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/main.drc
@@ -173,6 +173,11 @@ BEOL = bool_check?($beol)
 
 logger.info("BEOL enabled: #{BEOL}")
 
+# DUMMY
+DUMMY = bool_check?($dummy)
+
+logger.info("DUMMY enabled: #{DUMMY}")
+
 ## SLOW_VIA
 SLOW_VIA = bool_check?($slow_via)
 

--- a/gf180mcuD/libs.tech/klayout/tech/macros/drc_options.yml
+++ b/gf180mcuD/libs.tech/klayout/tech/macros/drc_options.yml
@@ -7,3 +7,4 @@ feol: true
 beol: true
 offgrid: 'true'
 connectivity: 'false'
+dummy: 'true'

--- a/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_drc.lydrc
+++ b/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_drc.lydrc
@@ -95,6 +95,8 @@ $offgrid = options["offgrid"]
 
 $conn_drc = options["connectivity"]
 
+$dummy = options["dummy"]
+
 unless File.exist?"#{run_dir}/macros/run_drc_main/main.drc"
   STDERR.puts "file run_drc_main.drc doesn't exist"
   exit

--- a/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_options.lym
+++ b/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_options.lym
@@ -173,7 +173,24 @@ require 'yaml'
     
   end
   mw.menu.insert_item("submenu.drc_menu.end", "connectivity", connectivity_action)
-  
+
+  #9 Setting dummy rules
+  dummy_action = RBA::Action::new
+  dummy_action.title = "Dummy rules"
+  dummy_action.checkable=(true)
+  dummy_action.checked=(false)
+  dummy_action.on_triggered do
+    options = YAML.load(File.read(__dir__ + "/drc_options.yml"))
+      if dummy_action.is_checked?
+        options["dummy"] = "true"
+        File.open(__dir__ + "/drc_options.yml", "w") { |file| file.write(options.to_yaml) }
+      else
+        options["dummy"] = "false"
+        File.open(__dir__ + "/drc_options.yml", "w") { |file| file.write(options.to_yaml) }
+      end
+
+  end
+  mw.menu.insert_item("submenu.drc_menu.end", "dummy", dummy_action)
   #####################################################################################
   # Adding LVS options
   #####################################################################################


### PR DESCRIPTION
Before, running the DRC from the klayout gui would error on an undefined DUMMY variable. This is liked with the recent additions of the dummy rules.