### PR TITLE
fix: fix various drc errors in guard ring and filler generation

### DIFF
--- a/gf180mcuD/libs.tech/klayout/tech/drc/filler_generation/fill_poly2.rb
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/filler_generation/fill_poly2.rb
@@ -76,8 +76,11 @@ tp.var("space_to_DNWELL", 2 / $ly.dbu)
 tp.var("space_to_LVPWELL", 1 / $ly.dbu)
 tp.var("space_to_Dualgate", 1 / $ly.dbu)
 
-# DPF.7
-tp.var("space_to_scribe_line", 25.7 / $ly.dbu)
+# DPF.7 / GR.2
+# DPF.7 specifies a minimum distance of 25.7 from dummy poly to the scribe line
+# GR.2 specifies a minimum distance of 10 from GUARD_RING_MK to prime die
+# Therefore, if GUARD_RING_MK is directly next to the scribe line, DPF.7 should actually be 26
+tp.var("space_to_scribe_line", 26 / $ly.dbu)
 
 # DPF.8
 tp.var("space_to_RES_MK", 19.7 / $ly.dbu)

--- a/gf180mcuD/libs.tech/klayout/tech/drc/gf180mcu.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/gf180mcu.drc
@@ -115,7 +115,7 @@ MIM_OPTION = $mim_option || 'B'
 logger.info("MIM Option selected: #{MIM_OPTION}")
 
 # OFFGRID
-OFFGRID = $offgrid != 'false'
+OFFGRID = bool_check?($offgrid)
 
 logger.info("Offgrid enabled:  #{OFFGRID}")
 
@@ -483,6 +483,8 @@ logger.info('Running all DUMMY rules') if DUMMY
 # %include rule_decks/dummy_metal3.drc
 # %include rule_decks/dummy_metal4.drc
 # %include rule_decks/dummy_metal5.drc
+
+# %include rule_decks/guard_ring.drc
 
 #================================================
 #-------------------- Tail ----------------------

--- a/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/guard_ring.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/guard_ring.drc
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+################################################################################################
+# Copyright 2023 GlobalFoundries PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################################
+
+if $BEOL
+  #================================================
+  #------------ Guard Ring / Seal Ring ------------
+  #================================================
+
+  guard_ring_comp = comp.interacting(guard_ring_mk)
+
+  # Rule GR.1: Min/Max GUARD_RING_MK overlap of guard ring comp: 0
+  logger.info('Executing rule GR.1')
+  gr1_l1 = guard_ring_mk.not_in(guard_ring_comp)
+  gr1_l1.output('GR.1', 'GR.1 : Min/Max GUARD_RING_MK overlap of guard ring comp: 0')
+  gr1_l1.forget
+
+  # Rule GR.2: Min GUARD_RING_MK space to prime die COMP, NWELL, Poly2, Metal 1, 2, 3, 4, 5 and metal Top: 10
+  logger.info('Executing rule GR.2')
+  gr2_l1 = comp.separation(guard_ring_mk, 10.um)
+  gr2_l1.output('GR.2', 'GR.2 : Min GUARD_RING_MK space to prime die COMP, NWELL, Poly2, Metal 1, 2, 3, 4, 5 and metal Top: 10')
+  gr2_l1.forget
+  gr2_l1 = nwell.separation(guard_ring_mk, 10.um)
+  gr2_l1.output('GR.2', 'GR.2 : Min GUARD_RING_MK space to prime die COMP, NWELL, Poly2, Metal 1, 2, 3, 4, 5 and metal Top: 10')
+  gr2_l1.forget
+  gr2_l1 = poly2.separation(guard_ring_mk, 10.um)
+  gr2_l1.output('GR.2', 'GR.2 : Min GUARD_RING_MK space to prime die COMP, NWELL, Poly2, Metal 1, 2, 3, 4, 5 and metal Top: 10')
+  gr2_l1.forget
+  gr2_l1 = poly2_dummy.separation(guard_ring_mk, 10.um)
+  gr2_l1.output('GR.2', 'GR.2 : Min GUARD_RING_MK space to prime die COMP, NWELL, Poly2, Metal 1, 2, 3, 4, 5 and metal Top: 10')
+  gr2_l1.forget
+  for metal in metals
+    gr2_l1 = metal.separation(guard_ring_mk, 10.um)
+    gr2_l1.output('GR.2', 'GR.2 : Min GUARD_RING_MK space to prime die COMP, NWELL, Poly2, Metal 1, 2, 3, 4, 5 and metal Top: 10')
+    gr2_l1.forget
+  end
+
+  # Rule GR.3: Minimum Pplus overlap of PCOMP inside guard ring: 0
+  logger.info('Executing rule GR.3')
+  gr3_l1 = guard_ring_comp.not_in(pplus)
+  gr3_l1.output('GR.3', 'GR.3 : Minimum Pplus overlap of PCOMP inside guard ring: 0')
+  gr3_l1.forget
+
+  # Rule GR.4: Minimum metal-n width (n= 1 to 6): 12
+  logger.info('Executing rule GR.4')
+  for metal in metals
+    gr4_l1 = metal.not_outside(guard_ring_mk).width(12.um)
+    gr4_l1.output('GR.4', 'GR.4 : Minimum metal-n width (n= 1 to 6): 12')
+    gr4_l1.forget
+  end
+
+  # Rule GR.6: Min PCOMP width: 16
+  logger.info('Executing rule GR.6')
+  gr6_l1 = comp.not_outside(guard_ring_mk).width(16.um)
+  gr6_l1.output('GR.6', 'GR.6 : Min PCOMP width: 16')
+  gr6_l1.forget
+
+  if WEDGE
+    # Rule GR.11: Pad opening on top of GUARD_RING_MK layer
+    logger.info('Executing rule GR.11')
+    gr11_l1 = guard_ring_mk.not_interacting(pad)
+    gr11_l1.output('GR.11', 'GR.11 : Pad opening on top of GUARD_RING_MK layer')
+    gr11_l1.forget
+  end
+
+  guard_ring_comp.forget
+
+end

--- a/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/layers_def.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/layers_def.drc
@@ -547,26 +547,31 @@ when '2LM'
   topmin1_via   = contact if contact_tables.include?(TABLE_NAME)
   top_metal     = metal2
   topmin1_metal = metal1
+  metals = [metal1, metal2]
 when '3LM'
   top_via       = via2 if via2_tables.include?(TABLE_NAME)
   topmin1_via   = via1 if via1_tables.include?(TABLE_NAME)
   top_metal     = metal3
   topmin1_metal = metal2
+  metals = [metal1, metal2, metal3]
 when '4LM'
   top_via = via3
   topmin1_via   = via2 if via2_tables.include?(TABLE_NAME)
   top_metal     = metal4
   topmin1_metal = metal3
+  metals = [metal1, metal2, metal3, metal4]
 when '5LM'
   top_via       = via4
   topmin1_via   = via3
   top_metal     = metal5
   topmin1_metal = metal4
+  metals = [metal1, metal2, metal3, metal4, metal5]
 when '6LM'
   top_via       = via5
   topmin1_via   = via4
   top_metal     = metaltop
   topmin1_metal = metal5
+  metals = [metal1, metal2, metal3, metal4, metal5, metaltop]
 else
   logger.error("Unknown metal stack #{METAL_LEVEL}")
   raise

--- a/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/pplus.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/pplus.drc
@@ -175,7 +175,7 @@ if FEOL
   # Rule PP.5di: Extension beyond COMP: For Outside DNWELL
   ## (i) For Pplus to NWELL space >= 0.43um for Pfield or LVPWELL tap. is 0.02µm
   logger.info('Executing rule PP.5di')
-  pp_5d_background = pplus.outside(dnwell).edges
+  pp_5d_background = pplus.not_interacting(guard_ring_mk).outside(dnwell).edges
   pp_5d_pcomp = pcomp.outside(dnwell).edges
   pp_5di_foreground = pp_5d_pcomp.not(nplus_edges).not(nwell_n_dn_sized_out)
   pp5di_l1 = pp_5d_background.enclosing(pp_5di_foreground, 0.02.um, projection)

--- a/gf180mcuD/libs.tech/klayout/tech/pymacros/sealring_cells/draw_sealring.py
+++ b/gf180mcuD/libs.tech/klayout/tech/pymacros/sealring_cells/draw_sealring.py
@@ -23,8 +23,6 @@ c2c_spacing = 0.7
 # via to via spacing
 v2v_spacing = 0.7
 
-pplus_comp_overlap = 0.03
-
 # When doing flip-chip packaging, the guard ring needs to be protected
 # If not, pad opening is required
 
@@ -32,7 +30,9 @@ pplus_comp_overlap = 0.03
 
 solid_layers_table = {
     "bonding": [
-        {"layer": Layers.COMP, "start": 0+pplus_comp_overlap, "end": 16-pplus_comp_overlap},
+        # Pad (Passivation) opening
+        {"layer": Layers.Pad, "start": 4, "end": 13},
+        {"layer": Layers.COMP, "start": 0, "end": 16},
         {"layer": Layers.Pplus, "start": 0, "end": 16},
         {"layer": Layers.GUARD_RING_MK, "start": 0, "end": 16},
         {"layer": Layers.Metal1, "start": 1, "end": 16},
@@ -41,11 +41,9 @@ solid_layers_table = {
         {"layer": Layers.Metal4, "start": 0, "end": 16},
         {"layer": Layers.Metal5, "start": 1, "end": 16},
         {"layer": Layers.MetalTop, "start": 0, "end": 16},
-        # Pad (Passivation) opening
-        {"layer": Layers.Pad, "start": 4, "end": 13},
     ],
     "flip-chip": [
-        {"layer": Layers.COMP, "start": 0+pplus_comp_overlap, "end": 16-pplus_comp_overlap},
+        {"layer": Layers.COMP, "start": 0, "end": 16},
         {"layer": Layers.Pplus, "start": 0, "end": 16},
         {"layer": Layers.GUARD_RING_MK, "start": 0, "end": 16},
         {"layer": Layers.Metal1, "start": 1, "end": 13},
@@ -59,71 +57,168 @@ solid_layers_table = {
 
 corner_polygons = {
     "bonding": {
-        Layers.COMP: [pya.DPoint(0+pplus_comp_overlap, 16), pya.DPoint(16-pplus_comp_overlap, 16), pya.DPoint(16, 16-pplus_comp_overlap), pya.DPoint(16, 0+pplus_comp_overlap)],
-        Layers.Pplus: [pya.DPoint(0, 16), pya.DPoint(16, 16), pya.DPoint(16, 0)],
-        Layers.GUARD_RING_MK: [
-            pya.DPoint(0, 16),
-            pya.DPoint(16, 16),
-            pya.DPoint(16, 0),
-        ],
-        Layers.Metal1: [
-            pya.DPoint(0, 16),
-            pya.DPoint(15, 16),
-            pya.DPoint(16, 15),
-            pya.DPoint(16, 0),
-        ],
-        Layers.Metal2: [pya.DPoint(0, 16), pya.DPoint(16, 16), pya.DPoint(16, 0)],
-        Layers.Metal3: [
-            pya.DPoint(0, 16),
-            pya.DPoint(15, 16),
-            pya.DPoint(16, 15),
-            pya.DPoint(16, 0),
-        ],
-        Layers.Metal4: [pya.DPoint(0, 16), pya.DPoint(16, 16), pya.DPoint(16, 0)],
-        Layers.Metal5: [
-            pya.DPoint(0, 16),
-            pya.DPoint(15, 16),
-            pya.DPoint(16, 15),
-            pya.DPoint(16, 0),
-        ],
-        Layers.MetalTop: [pya.DPoint(0, 16), pya.DPoint(16, 16), pya.DPoint(16, 0)],
         # Pad (Passivation) opening
         Layers.Pad: [
             pya.DPoint(3, 16),
             pya.DPoint(12, 16),
             pya.DPoint(16, 12),
             pya.DPoint(16, 3),
+            # Extend based on thickness
+            pya.DPoint(16 - 4, 3),
+            pya.DPoint(3, 16 - 4),
         ],
-    },
-    "flip-chip": {
-        Layers.COMP: [pya.DPoint(0+pplus_comp_overlap, 16), pya.DPoint(16-pplus_comp_overlap, 16), pya.DPoint(16, 16-pplus_comp_overlap), pya.DPoint(16, 0+pplus_comp_overlap)],
-        Layers.Pplus: [pya.DPoint(0, 16), pya.DPoint(16, 16), pya.DPoint(16, 0)],
+        Layers.COMP: [
+            pya.DPoint(0, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.Pplus: [
+            pya.DPoint(0, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
         Layers.GUARD_RING_MK: [
             pya.DPoint(0, 16),
             pya.DPoint(16, 16),
             pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.Metal1: [
+            pya.DPoint(0, 16),
+            pya.DPoint(15, 16),
+            pya.DPoint(16, 15),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.Metal2: [
+            pya.DPoint(0, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.Metal3: [
+            pya.DPoint(0, 16),
+            pya.DPoint(15, 16),
+            pya.DPoint(16, 15),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.Metal4: [
+            pya.DPoint(0, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.Metal5: [
+            pya.DPoint(0, 16),
+            pya.DPoint(15, 16),
+            pya.DPoint(16, 15),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.MetalTop: [
+            pya.DPoint(0, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+    },
+    "flip-chip": {
+        Layers.COMP: [
+            pya.DPoint(0, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.Pplus: [
+            pya.DPoint(0, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
+        ],
+        Layers.GUARD_RING_MK: [
+            pya.DPoint(0, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 0),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 0),
+            pya.DPoint(0, 16 - 7),
         ],
         Layers.Metal1: [
             pya.DPoint(3, 16),
             pya.DPoint(15, 16),
             pya.DPoint(16, 15),
             pya.DPoint(16, 3),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 3),
+            pya.DPoint(3, 16 - 7),
         ],
-        Layers.Metal2: [pya.DPoint(3, 16), pya.DPoint(16, 16), pya.DPoint(16, 3)],
+        Layers.Metal2: [
+            pya.DPoint(3, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 3),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 3),
+            pya.DPoint(3, 16 - 7),
+        ],
         Layers.Metal3: [
             pya.DPoint(3, 16),
             pya.DPoint(15, 16),
             pya.DPoint(16, 15),
             pya.DPoint(16, 3),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 3),
+            pya.DPoint(3, 16 - 7),
         ],
-        Layers.Metal4: [pya.DPoint(3, 16), pya.DPoint(16, 16), pya.DPoint(16, 3)],
+        Layers.Metal4: [
+            pya.DPoint(3, 16),
+            pya.DPoint(16, 16),
+            pya.DPoint(16, 3),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 3),
+            pya.DPoint(3, 16 - 7),
+        ],
         Layers.Metal5: [
             pya.DPoint(3, 16),
             pya.DPoint(15, 16),
             pya.DPoint(16, 15),
             pya.DPoint(16, 3),
+            # Extend based on thickness
+            pya.DPoint(16 - 7, 3),
+            pya.DPoint(3, 16 - 7),
         ],
-        Layers.MetalTop: [pya.DPoint(3, 16), pya.DPoint(16, 16), pya.DPoint(16, 3)],
+        Layers.MetalTop: [
+        pya.DPoint(3, 16),
+        pya.DPoint(16, 16),
+        pya.DPoint(16, 3),
+        # Extend based on thickness
+        pya.DPoint(16 - 7, 3),
+        pya.DPoint(3, 16 - 7),
+        ],
     },
 }
 

--- a/gf180mcuD/libs.tech/librelane/config.tcl
+++ b/gf180mcuD/libs.tech/librelane/config.tcl
@@ -52,9 +52,10 @@ set ::env(DEFAULT_CORNER) "nom_tt_025C_5v00"
 set ::env(TIMING_VIOLATION_CORNERS) "*tt*"
 
 # Technology LEF
-set ::env(TECH_LEF) [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/techlef/*__nom.tlef"]
-set ::env(TECH_LEF_MIN)  [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/techlef/*__min.tlef"]
-set ::env(TECH_LEF_MAX)  [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/techlef/*__max.tlef"]
+set ::env(TECH_LEFS) [dict create]
+dict set ::env(TECH_LEFS) nom_* [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/techlef/*__nom.tlef"]
+dict set ::env(TECH_LEFS) min_* [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/techlef/*__min.tlef"]
+dict set ::env(TECH_LEFS) max_* [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/techlef/*__max.tlef"]
 
 # Standard cells
 set ::env(CELL_LEFS) [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lef/*.lef"]
@@ -167,6 +168,7 @@ dict set ::env(KLAYOUT_DRC_OPTIONS) beol true
 dict set ::env(KLAYOUT_DRC_OPTIONS) dummy true
 dict set ::env(KLAYOUT_DRC_OPTIONS) offgrid true
 dict set ::env(KLAYOUT_DRC_OPTIONS) conn_drc true
+dict set ::env(KLAYOUT_DRC_OPTIONS) wedge true
 dict set ::env(KLAYOUT_DRC_OPTIONS) run_mode "deep"
 
 set ::env(KLAYOUT_DENSITY_RUNSET) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/drc/rule_decks/density.drc"


### PR DESCRIPTION
guard ring:
- bugfix: add glass cut
- fix: make pplus overlap zero

filler generation:
- make sure 10um min distance is respected

KLayout DRC:
- fix: update PP.5di to ignore pplus in guard ring
- add: GR.1, GR.2, GR.3, GR.4, GR.6, GR.11