### PR TITLE
Klayout parallel drc

### DIFF
--- a/gf180mcuD/libs.tech/klayout/tech/drc/gf180mcu.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/gf180mcu.drc
@@ -16,13 +16,58 @@
 # limitations under the License.
 ################################################################################################
 
+################################################################################################
+# INPUT OPTIONS
+################################################################################################
+#
+# Required:
+#   $input                  - Path to the input GDS/OASIS layout file
+#   $report                 - Path for the DRC report output file (.lyrdb format)
+#
+# Optional - Processing Control:
+#   $topcell                - Name of the top cell to process (if not specified, uses top cell)
+#   $thread_klayout_drc     - Number of threads for KLayout DRC functions (default: number of processors)
+#   $thread_workers         - Number of high-level worker threads (default: number of processors)
+#   $run_mode               - Execution mode: 'tiling', 'deep', or flat (default: flat)
+#   $verbose                - Enable verbose output: 'true' or 'false' (default: false)
+#
+# Optional - Technology Options:
+#   $table_name             - Rule table name to run (default: 'main')
+#                             Options: dnwell, dnwell_split, nwell, nwell_split, lvpwell,
+#                                      lvpwell_split, nat, nat_split, ldnmos, ldnmos_split,
+#                                      ldpmos, ldpmos_split, main
+#   $metal_level            - Metal stack configuration (default: '5LM')
+#                             Options: '3LM', '4LM', '5LM', '6LM'
+#   $metal_top              - Top metal thickness (default: '11K')
+#   $mim_option             - MIM capacitor option (default: 'B')
+#                             Options: 'A' or 'B'
+#
+# Optional - Rule Enablement (true/false):
+#   $feol                   - Enable Front-End-Of-Line rules (default: false)
+#   $beol                   - Enable Back-End-Of-Line rules (default: false)
+#   $conn_drc               - Enable connectivity-based DRC rules (default: false)
+#   $split_deep             - Enable split deep rules (default: false)
+#   $offgrid                - Enable off-grid checking (default: false)
+#   $wedge                  - Enable wedge bonding rules (default: false)
+#   $ball                   - Enable ball bonding rules (default: false)
+#   $gold                   - Enable gold metallization rules (default: false)
+#   $dummy                  - Enable dummy fill rules (default: false)
+#   $dummy_no_sub_prev      - Disable dummy subtraction prevention (default: false)
+#   $slow_via               - Enable slow via rules (default: false)
+#
+# Example usage:
+#   klayout -b -r gf180mcu_drc.rb -rd input=design.gds -rd report=drc_results.lyrdb \
+#           -rd metal_level=5LM -rd feol=true -rd beol=true -rd conn_drc=true
+#
+################################################################################################
+
 #=======================================================================================================================
 #--------------------------------------------- GF 0.18um MCU DRC RULE DECK ---------------------------------------------
 #=======================================================================================================================
 require 'time'
 require 'logger'
 require 'etc'
-
+require_relative './parallel_rule_checker'
 exec_start_time = Time.now
 
 # Custom formatter including timestamp and memory usage
@@ -52,17 +97,39 @@ if $input
   end
 end
 
-logger.info('Loading database to memory is complete.')
+# Number of threads for KLayout DRC functions
+# They can rarely keep the processor busy, as there seem to be memory
+# bottlenecks. High level multi threading used in addition below
+thread_klayout_drc = Integer($thread_klayout_drc || Etc.nprocessors)
+threads(thread_klayout_drc)
 
-if $report
-  logger.info("GF180MCU Klayout DRC runset output at: #{$report}")
-  report('DRC Run Report at', $report)
-else
-  layout_dir = Pathname.new(RBA::CellView.active.filename).parent.realpath
-  report_path = layout_dir.join('gf180_drc.lyrdb').to_s
-  logger.info("GF180MCU Klayout DRC runset output at default location: #{report_path}")
-  report('DRC Run Report at', report_path)
+logger.info("Number of threads to use for klayout drc funtions #{thread_klayout_drc}")
+
+# Number of threads for KLayout DRC functions
+# They can rarely keep the processor busy, as there seem to be memory
+# bottlenecks. High level multi threading used in addition below
+thread_workers = Integer($thread_workers || Etc.nprocessors)
+logger.info("Number of high level worker threads #{thread_workers}")
+
+# If thread_workers is 1, run check as they were previously, all in the same binding
+# with a report made at the beginning.
+if thread_workers == 1
+  if $report
+    logger.info("GF180MCU Klayout DRC runset output at: #{$report}")
+    report('DRC Run Report at', $report)
+  else
+    layout_dir = Pathname.new(RBA::CellView.active.filename).parent.realpath
+    report_path = layout_dir.join('gf180_drc.lyrdb').to_s
+    logger.info("GF180MCU Klayout DRC runset output at default location: #{report_path}")
+    report('DRC Run Report at', report_path)
+  end
 end
+
+if not defined? $report
+  raise StandardError.new "report must be defined"
+end
+
+logger.info('Loading database to memory is complete.')
 
 #================================================
 #------------------ SWITCHES --------------------
@@ -119,19 +186,11 @@ OFFGRID = bool_check?($offgrid)
 
 logger.info("Offgrid enabled:  #{OFFGRID}")
 
-# threads
-if $thr
-  threads($thr)
-else
-  thr ||= Etc.nprocessors
-  threads(thr)
-end
-
-logger.info("Number of threads to use #{$thr}")
 
 #=== PRINT DETAILS ===
 
-verbose(bool_check?($verbose))
+$verbose = bool_check?($verbose) || false
+verbose($verbose)
 
 logger.info("Verbose mode: #{$verbose}")
 
@@ -427,77 +486,88 @@ logger.info('Running all FEOL rules') if FEOL
 logger.info('Running all BEOL rules') if BEOL
 logger.info('Running all DUMMY rules') if DUMMY
 
-# %include rule_decks/comp.drc
-# %include rule_decks/contact.drc
-# %include rule_decks/contact_split.drc
-# %include rule_decks/dnwell.drc
-# %include rule_decks/dnwell_split.drc
-# %include rule_decks/drc_bjt.drc
-# %include rule_decks/dualgate.drc
-# %include rule_decks/efuse.drc
-# %include rule_decks/esd.drc
-# %include rule_decks/geom.drc
-# %include rule_decks/hres.drc
-# %include rule_decks/ldnmos.drc
-# %include rule_decks/ldnmos_split.drc
-# %include rule_decks/ldpmos.drc
-# %include rule_decks/ldpmos_split.drc
-# %include rule_decks/lres.drc
-# %include rule_decks/lvpwell.drc
-# %include rule_decks/lvpwell_split.drc
-# %include rule_decks/lvs_bjt.drc
-# %include rule_decks/mcell.drc
-# %include rule_decks/metal1.drc
-# %include rule_decks/metal1_split.drc
-# %include rule_decks/metal2.drc
-# %include rule_decks/metal3.drc
-# %include rule_decks/metal4.drc
-# %include rule_decks/metal5.drc
-# %include rule_decks/metaltop_30k.drc
-# %include rule_decks/metaltop.drc
-# %include rule_decks/mim_a.drc
-# %include rule_decks/mim_b.drc
-# %include rule_decks/nat.drc
-# %include rule_decks/nat_split.drc
-# %include rule_decks/nplus.drc
-# %include rule_decks/nwell.drc
-# %include rule_decks/nwell_split.drc
-# %include rule_decks/otp_mk.drc
-# %include rule_decks/poly2.drc
-# %include rule_decks/pplus.drc
-# %include rule_decks/pres.drc
-# %include rule_decks/sab.drc
-# %include rule_decks/sram_3p3.drc
-# %include rule_decks/sram_5p0.drc
-# %include rule_decks/tail.drc
-# %include rule_decks/via1.drc
-# %include rule_decks/via1_split.drc
-# %include rule_decks/via2.drc
-# %include rule_decks/via2_split.drc
-# %include rule_decks/via3.drc
-# %include rule_decks/via3_split.drc
-# %include rule_decks/via4.drc
-# %include rule_decks/via4_split.drc
-# %include rule_decks/via5.drc
-# %include rule_decks/ymtp_mk.drc
+rule_files = ["./rule_decks/comp.drc",
+              "./rule_decks/contact.drc",
+              "./rule_decks/contact_split.drc",
+              "./rule_decks/dnwell.drc",
+              "./rule_decks/dnwell_split.drc",
+              "./rule_decks/drc_bjt.drc",
+              "./rule_decks/dualgate.drc",
+              "./rule_decks/efuse.drc",
+              "./rule_decks/esd.drc",
+              "./rule_decks/geom.drc",
+              "./rule_decks/hres.drc",
+              "./rule_decks/ldnmos.drc",
+              "./rule_decks/ldnmos_split.drc",
+              "./rule_decks/ldpmos.drc",
+              "./rule_decks/ldpmos_split.drc",
+              "./rule_decks/lres.drc",
+              "./rule_decks/lvpwell.drc",
+              "./rule_decks/lvpwell_split.drc",
+              "./rule_decks/lvs_bjt.drc",
+              "./rule_decks/mcell.drc",
+              "./rule_decks/metal1.drc",
+              "./rule_decks/metal1_split.drc",
+              "./rule_decks/metal2.drc",
+              "./rule_decks/metal3.drc",
+              "./rule_decks/metal4.drc",
+              "./rule_decks/metal5.drc",
+              "./rule_decks/metaltop_30k.drc",
+              "./rule_decks/metaltop.drc",
+              "./rule_decks/mim_a.drc",
+              "./rule_decks/mim_b.drc",
+              "./rule_decks/nat.drc",
+              "./rule_decks/nat_split.drc",
+              "./rule_decks/nplus.drc",
+              "./rule_decks/nwell.drc",
+              "./rule_decks/nwell_split.drc",
+              "./rule_decks/otp_mk.drc",
+              "./rule_decks/poly2.drc",
+              "./rule_decks/pplus.drc",
+              "./rule_decks/pres.drc",
+              "./rule_decks/sab.drc",
+              "./rule_decks/sram_3p3.drc",
+              "./rule_decks/sram_5p0.drc",
+              "./rule_decks/via1.drc",
+              "./rule_decks/via1_split.drc",
+              "./rule_decks/via2.drc",
+              "./rule_decks/via2_split.drc",
+              "./rule_decks/via3.drc",
+              "./rule_decks/via3_split.drc",
+              "./rule_decks/via4.drc",
+              "./rule_decks/via4_split.drc",
+              "./rule_decks/via5.drc",
+              "./rule_decks/ymtp_mk.drc",
+              "./rule_decks/dummy_exclude.drc",
+              "./rule_decks/dummy_comp.drc",
+              "./rule_decks/dummy_poly2.drc",
+              "./rule_decks/dummy_metal1.drc",
+              "./rule_decks/dummy_metal2.drc",
+              "./rule_decks/dummy_metal3.drc",
+              "./rule_decks/dummy_metal4.drc",
+              "./rule_decks/dummy_metal5.drc",
+              "./rule_decks/guard_ring.drc",
+              "./rule_decks/cup.drc",
+             ]
 
-# Always enabled
-# %include rule_decks/dummy_exclude.drc
+rule_files_abs = []
+rule_files.each do | element |
+  rule_files_abs.push(File.join(File.dirname(__FILE__), element))
+end
 
-# %include rule_decks/dummy_comp.drc
-# %include rule_decks/dummy_poly2.drc
-# %include rule_decks/dummy_metal1.drc
-# %include rule_decks/dummy_metal2.drc
-# %include rule_decks/dummy_metal3.drc
-# %include rule_decks/dummy_metal4.drc
-# %include rule_decks/dummy_metal5.drc
+if thread_workers == 1
+  rule_files_abs.each do | element |
+    eval(File.read(element), binding, element)
+  end
+else
+  checker = ParallelRuleChecker.new(rule_files_abs, binding, logger, num_workers: thread_workers)
+  results = checker.run
 
-# %include rule_decks/guard_ring.drc
+  results.save($report)
+end
 
-# %include rule_decks/cup.drc
-
-#================================================
-#-------------------- Tail ----------------------
-#================================================
+##================================================
+##-------------------- Tail ----------------------
+##================================================
 
 # %include rule_decks/tail.drc

--- a/gf180mcuD/libs.tech/klayout/tech/drc/gf180mcu.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/gf180mcu.drc
@@ -67,7 +67,8 @@
 require 'time'
 require 'logger'
 require 'etc'
-require_relative './parallel_rule_checker'
+puts File.expand_path('parallel_rule_checker.rb', File.dirname(__FILE__))
+require(File.expand_path('parallel_rule_checker.rb', File.dirname(__FILE__))) # 'parallel_rule_checker.rb'
 exec_start_time = Time.now
 
 # Custom formatter including timestamp and memory usage

--- a/gf180mcuD/libs.tech/klayout/tech/drc/parallel_rule_checker.rb
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/parallel_rule_checker.rb
@@ -1,0 +1,258 @@
+require 'thread'
+require 'stringio'
+require 'io/wait'
+require 'tmpdir'
+
+class ParallelRuleChecker
+  def initialize(rule_files, rule_binding, logger, num_workers: 4)
+    @rule_files = rule_files
+    @rule_binding = rule_binding
+    @logger = logger
+    @num_workers = num_workers + 1 # +1 because master worker does no work
+    timestamp = Time.now.strftime("drc_run_%Y_%m_%d_%H_%M_%S__")
+    @tmpdir = Dir.mktmpdir(timestamp)
+  end
+
+  def run
+    _run(@rule_files)
+  end
+
+  private
+  def merge_databases(db1, db2)
+    # Copy metadata from db2 to db1 if db1 is empty
+    if db1.description.empty? && !db2.description.empty?
+      db1.description = db2.description
+    end
+
+    if db1.generator.empty? && !db2.generator.empty?
+      db1.generator = db2.generator
+    end
+
+    if db1.top_cell_name.empty? && !db2.top_cell_name.empty?
+      db1.top_cell_name = db2.top_cell_name
+    end
+
+    if db1.original_file.empty? && !db2.original_file.empty?
+      db1.original_file = db2.original_file
+    end
+
+    category_map = {}
+    cell_map = {}
+
+    # Copy cells
+    db2.each_cell do |cell2|
+      cell1 = db1.cell_by_qname(cell2.qname)
+      if cell1.nil?
+        cell1 = cell2.variant.empty? ?
+          db1.create_cell(cell2.name) :
+          db1.create_cell(cell2.name, cell2.variant)
+      end
+      cell_map[cell2.rdb_id] = cell1
+    end
+
+    # Helper to get the full path of a category by traversing up the tree
+    get_full_path = lambda do |cat|
+      path_parts = []
+      current = cat
+      while current
+        path_parts.unshift(current.name)
+        current = current.parent
+      end
+      path_parts.join('.')
+    end
+
+    # Copy categories recursively - preserving actual hierarchy
+    copy_category = lambda do |cat2, parent1|
+      # Check if category already exists
+      if parent1.nil?
+        # Top-level category
+        cat1 = db1.category_by_path(cat2.name)
+        if cat1.nil?
+          cat1 = db1.create_category(cat2.name)
+        end
+      else
+        # Sub-category - check within parent
+        parent_path = get_full_path.call(parent1)
+        full_path = "#{parent_path}.#{cat2.name}"
+        cat1 = db1.category_by_path(full_path)
+        if cat1.nil?
+          cat1 = db1.create_category(parent1, cat2.name)
+        end
+      end
+
+      # Copy description
+      if cat1.description.empty? && !cat2.description.empty?
+        cat1.description = cat2.description
+      end
+
+      # Store in map using the full path from db2
+      full_path2 = get_full_path.call(cat2)
+      category_map[cat2.rdb_id] = cat1
+
+      # Recursively copy sub-categories
+      cat2.each_sub_category do |sub_cat2|
+        copy_category.call(sub_cat2, cat1)
+      end
+    end
+
+    # Copy all top-level categories
+    db2.each_category do |cat2|
+      copy_category.call(cat2, nil)
+    end
+
+    # Copy items
+    db2.each_item do |item2|
+      cell1 = cell_map[item2.cell_id]
+      cat1 = category_map[item2.category_id]
+
+      if cell1 && cat1
+        item1 = db1.create_item(cell1.rdb_id, cat1.rdb_id)
+
+        # Copy values
+        item2.each_value { |value| item1.add_value(value) }
+
+        ## Copy tags
+        #item2.each_tag { |tag_id| item1.add_tag(tag_id) }
+      end
+    end
+
+    db1
+  end
+
+  def _run(rule_files)
+    rule_files = @rule_files
+    results = []
+    pids = []
+
+    puppets = []
+    pipes = @num_workers.times.map { IO.pipe }
+    @num_workers.times do |i|
+      reader, writer = pipes[i]
+      master_to_puppet_r, master_to_puppet_w = IO.pipe
+      puppet_to_master_r, puppet_to_master_w = IO.pipe
+
+      pid = fork do
+        reader.close
+        # Child (puppet)
+        chunk_results = []
+        master_to_puppet_w.close
+        puppet_to_master_r.close
+
+        # Tell master we are ready
+        puppet_to_master_w.puts "ready"
+
+        loop do
+
+          # Wait for next task (blocks until master writes something)
+          task = master_to_puppet_r.gets
+          if task == nil
+            sleep(0.01)
+            next
+          end
+          task.chomp!
+
+          break if task == "shutdown"
+
+          @logger.info("Worker #{i}: Processing #{File.basename(task)}")
+          begin
+            result = execute_rule(task)
+            chunk_results << result
+          rescue => e
+            @logger.info("Worker #{i}: Error processing #{File.basename(task)} : #{e.message}")
+
+            chunk_results << { file: task, error: e.message }
+          end
+          @logger.info("Worker #{i}: Done processing #{File.basename(task)}")
+          # Tell master we are ready
+          puppet_to_master_w.puts "ready"
+
+        end
+        @logger.info("Worker #{i}: Shutting down")
+
+        # Send results back to parent
+        writer.write(Marshal.dump(chunk_results))
+        writer.close
+        exit
+      end
+
+      writer.close
+      master_to_puppet_r.close
+      puppet_to_master_w.close
+
+      puppets << {
+        pid: pid,
+        to_puppet: master_to_puppet_w,
+        from_puppet: puppet_to_master_r
+      }
+    end
+
+    # Master loop
+    strings_queue = rule_files.dup
+
+    while !strings_queue.empty? || puppets.any?
+      # Wait for ready puppets
+      ready_pipes = puppets.map { |p| p[:from_puppet] }.select { |r| r.ready? }
+
+      ready_pipes.each do |pipe|
+        pipe.gets # remove "ready"
+        puppet = puppets.find { |p| p[:from_puppet] == pipe }
+
+        if strings_queue.empty?
+          # No more tasks, send shutdown
+          puppet[:to_puppet].puts "shutdown"
+          puppet[:to_puppet].flush
+          puppets.delete(puppet)
+        else
+          # Send next task
+          next_string = strings_queue.shift
+          puppet[:to_puppet].puts next_string
+          puppet[:to_puppet].flush
+        end
+      end
+    end
+
+    # Collect results from all processes
+    pipes.each do |reader, _|
+      chunk_results = Marshal.load(reader.read)
+      results.concat(chunk_results)
+      reader.close
+    end
+
+    # Wait for all puppets to finish
+    puppets.each do |p|
+      Process.wait(p[:pid])
+    end
+
+    @logger.info("All workers completed. Total results: #{results.size}")
+
+    aggregated_res = RBA::ReportDatabase.new()
+    results.each do | element |
+      incoming_rep = RBA::ReportDatabase.new()
+      incoming_rep.load(element[:result])
+      aggregated_res = merge_databases(aggregated_res, incoming_rep)
+    end
+
+    aggregated_res
+  end
+
+  def execute_rule(file)
+    report_location = File.join(@tmpdir, "#{File.basename(file)}.lyrdb")
+    @rule_binding.eval(%(r = report('Report for #{File.basename(file)}', '#{report_location}')))
+    rule_code = File.read(file)
+    eval(rule_code, @rule_binding, file)
+
+    @rule_binding.local_variable_get(:r).rdb.save(report_location)
+    {
+      file: File.basename(file),
+      result: report_location,
+      timestamp: Time.now
+    }
+  rescue => e
+    {
+      file: File.basename(file),
+      result: "ERROR: #{e.message}",
+      timestamp: Time.now
+    }
+  end
+
+end

--- a/gf180mcuD/libs.tech/klayout/tech/macros/drc_options.yml
+++ b/gf180mcuD/libs.tech/klayout/tech/macros/drc_options.yml
@@ -8,3 +8,4 @@ beol: true
 offgrid: 'true'
 connectivity: 'false'
 dummy: 'true'
+thread_workers: 2

--- a/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_drc.lydrc
+++ b/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_drc.lydrc
@@ -87,13 +87,28 @@ cmd = "klayout -b -r #{run_dir}/drc/gf180mcu.drc " +
         "-rd conn_drc=#{options["connectivity"]} "+
         "-rd verbose=#{options["verbose"]} " +
         "-rd topcell=#{options["top_cell_name"]} " +
+        "-rd thread_workers=1 " +
         "-rd report=main.lyrdb"
 
 ## start running drc
 puts "######### running #{cmd}"
-system("#{cmd}")
-status = $?
 
+IO.popen("#{cmd}") do |io|
+  while !io.eof?
+    # Check if data is ready
+    ready = IO.select([io], nil, nil, 0.01)
+
+    if ready
+      line = io.gets
+      log(line.chomp) if line
+    else
+      # Timeout - just yield to UI
+      RBA::Application.instance.process_events rescue nil
+    end
+  end
+end
+
+status = $?
 if status.exitstatus != 0
   STDERR.puts "Error: drc script failed with exit code #{status.exitstatus}"
   exit status.exitstatus

--- a/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_drc.lydrc
+++ b/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_drc.lydrc
@@ -87,7 +87,7 @@ cmd = "klayout -b -r #{run_dir}/drc/gf180mcu.drc " +
         "-rd conn_drc=#{options["connectivity"]} "+
         "-rd verbose=#{options["verbose"]} " +
         "-rd topcell=#{options["top_cell_name"]} " +
-        "-rd thread_workers=1 " +
+        "-rd thread_workers=#{options["thread_workers"]} " +
         "-rd report=main.lyrdb"
 
 ## start running drc

--- a/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_drc.lydrc
+++ b/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_drc.lydrc
@@ -36,6 +36,18 @@ require "yaml"
 layout_path = Pathname.new(RBA::CellView.active.filename)
 layout_dir = layout_path.split()[0]
 
+lay_view = RBA::LayoutView::current
+if lay_view.is_dirty
+    v = RBA::MessageBox::warning("Outdated save file", "DRC check runs on the save file, but it outdated. Would you like to save now?", RBA::MessageBox::Yes + RBA::MessageBox::No)
+     if v == RBA::MessageBox::Yes
+       # Get the main window
+       mw = RBA::MainWindow.instance
+
+       # Trigger the File->Save menu action
+       mw.menu.action("file_menu.save").trigger
+    end
+end
+
 ## read saved options from yaml file
 dir_path = File.dirname(File.expand_path(__FILE__))
 options = YAML.load(File.read(dir_path + "/drc_options.yml"))
@@ -43,29 +55,7 @@ options = YAML.load(File.read(dir_path + "/drc_options.yml"))
 ## reading the parent directory of the current file
 run_dir = File.expand_path("..", dir_path)
 
-## read the log of drc run to get output lydb file paths if run_dir option is disables 
-gds_name = layout_path.split()[1].to_s.split(".")[0]
-
-out_dir = "#{run_dir}/macros/run_drc_main"
-
-if Dir.exist?out_dir
-  `rm #{out_dir}/drc_run*.log`
-end
-
-## create options passed to run_drc.py 
-options_str = "--variant=#{options["variant"]} --run_dir=#{run_dir}/macros/run_drc_main --macro_gen"
-
-## run_drc command line
-cmd = "python3 #{run_dir}/drc/run_drc.py --path=#{layout_path} #{options_str}"
-
-## start running drc 
-puts "######### running #{cmd}"
-drc_res = `#{cmd}`
-
-## pass options to main.drc
-$run_mode = options["run_mode"]
-
-if options["variant"] == "A" 
+if options["variant"] == "A"
   $metal_top = "30K"
   $metal_level = "3LM"
   $mim_option = "A"
@@ -83,34 +73,37 @@ elsif options["variant"] == "D"
   $mim_option = "B"
 end
 
-$topcell = options["top_cell_name"]
+## run_drc command line
+cmd = "klayout -b -r #{run_dir}/drc/gf180mcu.drc " +
+        "-rd input=#{layout_path} " +
+        "-rd mim_option=#{$mim_option} " +
+        "-rd metal_top=#{$metal_top} " +
+        "-rd metal_level=#{$metal_level} " +
+        "-rd feol=#{options["feol"]} " +
+        "-rd beol=#{options["beol"]} " +
+        "-rd offgrid=#{options["offgrid"]} " +
+        "-rd run_mode=#{options["run_mode"]} " +
+        "-rd dummy=#{options["dummy"]} " +
+        "-rd conn_drc=#{options["connectivity"]} "+
+        "-rd verbose=#{options["verbose"]} " +
+        "-rd topcell=#{options["top_cell_name"]} " +
+        "-rd report=main.lyrdb"
 
-$verbose = options["verbose"]
+## start running drc
+puts "######### running #{cmd}"
+system("#{cmd}")
+status = $?
 
-$feol = options["feol"]
-
-$beol = options["beol"]
-
-$offgrid = options["offgrid"]
-
-$conn_drc = options["connectivity"]
-
-$dummy = options["dummy"]
-
-unless File.exist?"#{run_dir}/macros/run_drc_main/main.drc"
-  STDERR.puts "file run_drc_main.drc doesn't exist"
-  exit
+if status.exitstatus != 0
+  STDERR.puts "Error: drc script failed with exit code #{status.exitstatus}"
+  exit status.exitstatus
 end
 
-## include run files
-
-$report = "antenna.lyrdb"
-#%include ../drc/rule_decks/antenna.drc
-$report = "density.lyrdb"
-#%include ../drc/rule_decks/density.drc
-$report = "main.lyrdb"
-#%include run_drc_main/main.drc
-
+resulting_report = RBA::ReportDatabase.new()
+resulting_report.load("main.lyrdb")
+view = RBA::LayoutView::current
+rdb_index = view.add_rdb(resulting_report)
+view.show_rdb(rdb_index, view.active_cellview_index)
 
 </text>
 </klayout-macro>

--- a/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_options.lym
+++ b/gf180mcuD/libs.tech/klayout/tech/macros/gf180mcu_options.lym
@@ -191,6 +191,21 @@ require 'yaml'
 
   end
   mw.menu.insert_item("submenu.drc_menu.end", "dummy", dummy_action)
+
+  # Thread_workers
+  thread_workers_action = RBA::Action::new
+  thread_workers_action.title = "Thread workers"
+  thread_workers_action.on_triggered do
+    thread_workers_select = RBA::InputDialog::ask_int_ex("Number of thread workers", "Select numbers of thread to use for DRC check. Make sure you have enough RAM to support the threads. '0' uses the maximum available cores", 0, 0,4096, 1)
+      options = YAML.load(File.read(__dir__ + "/drc_options.yml"))
+      if thread_workers_select
+        options["thread_workers"] = thread_workers_select
+        File.open(__dir__ + "/drc_options.yml", "w") { |file| file.write(options.to_yaml) }
+      end
+
+  end
+  mw.menu.insert_item("submenu.drc_menu.end", "thread_workers", thread_workers_action)
+
   #####################################################################################
   # Adding LVS options
   #####################################################################################


### PR DESCRIPTION
Here is a mockup of what a nicely integrated, parallel DRC check in klayout could look like.
While it works flawlessly, there is room for a bit of discussion (see below). One implementation point that stands out is that klayout is not very flexible in the way it deals with drc reports, which causes a bit of gymnastics that should ideally be integrated in klayout core rather than here.

It works well, with significant performance improvement similar or better than `run_drc.py` and much better than just the previous `gf180mcu.drc`. This is possible because one-rule-after-another cannot maintain CPUs fed throughout the execution. Worse yet, it seems that when run from the gui, only a single core at most was be used (as opposed to starting it from command line). The performance is similar to the python approach, but with the significant advantage of generating a single report file. It should actually be a little faster, as the general layer calculation are only done once with the present method.

Some light gymnastics / hacks are required to end up with a single report and display it through the gui.

This implementation suffers from a few disadvantages:
* As in run_drc.py, unnecessary files are created to hold partial drc checks. It is not possible to change this without modifying klayout core.
* For reasons that I ignore, forking in the gui thread seem to have issues that the command line approach does not have. For gui, I thus spawn a new instance of klayout from command line. This has little impact on large designs, but small design drc execution time will be lower bounded by it
* The klayout gui interface simply hangs while the check is ongoing. Before the check would at least provide some amount of GUI updates.
* WaiveDB is not implemented (can be added)
* A tmp directory is created to hold temporary files. It is currently not cleared at the end of execution. (can be added)

Note that run_drc.py is not affected, as it uses the files in macros/run_drc_main

I will publish some benchmark numbers tomorrow. So far I've seen 4x improvements in speed for a gui check for a middle size design.

## Benchmark

Run time:
| Design  | New gf180mcu.drc (32 workers) [s] | Old gf180mcu.drc [s] | run_drc.py (32 threads, patched for dummy tests) [s] |
| ------------- | ------------- | -------- | --------- |
| [Trivial Design (bondpad)](https://github.com/Scafir/gf180mcu-project-trident-gf180-teststructure/blob/complete/klayout/gf180mcu_bondpad_70x100um.gds)  | 2.6  | 2.94 | 7.06 |
| [Simple full chip design (unfilled)](https://github.com/Scafir/gf180mcu-project-trident-gf180-teststructure/blob/complete/klayout/top.layout.gds.gz) | 46.51  | 285.72 | 43.09 |
| [Simple full chip design (filled)](https://github.com/Scafir/gf180mcu-project-trident-gf180-teststructure/blob/complete/klayout/top.layout.filled_db0p001.gds.gz) | 248.91 | 1351.2 | 256.4 | 
<details>
  <summary>Commands</summary>
  For new gf180mcu.drc: `time klayout -b -r /path/to/gf180mcu.drc -rd input=/path/to/layout.gds -rd feol=true -rd beol=true -rd conn_drc=true -rd dummy=true -rd offgrid=true -rd run_mode=deep -rd out=a.lyrdb`
  For old gf180mcu.drc: `time klayout -b -r /path/to/gf180mcu.drc -rd input=/path/to/layout.gds -rd feol=true -rd beol=true -rd conn_drc=true -rd dummy=true -rd offgrid=true -rd run_mode=deep`
  For run_drc.py: `time python3.13 /home/claforge/Documents/gf180mcu/gf180mcuD/libs.tech/klayout/tech/drc/run_drc.py --path=/home/claforge/cernbox/CERN/PhD/gf180mcu-project-trident-gf180-teststructure/klayout/top.layout.gds.gz --variant=D --mp 32 --run_mode=deep`
</details>


Ram usage:
| Design  | New gf180mcu.drc (32 workers) [Gb] | Old gf180mcu.drc [Gb] | run_drc.py (32 threads, patched for dummy tests) [Gb] |
| ------------- | ------------- | -------- | --------- |
| [Simple full chip design (unfilled)](https://github.com/Scafir/gf180mcu-project-trident-gf180-teststructure/blob/complete/klayout/top.layout.gds.gz) | 5.6  | 2.3 | 12 |

Ran on an AMD Ryzen 9 9950X CPU (32 cores)

The main difference in terms of performance between my implementation and run_drc.py is that my implementation runs the preliminary calculations once, and then forks. The run_drc.py runs everything in parallel. Depending on the number of tests to run, the cost of the preliminary calculation and the number of threads this can be good or bad in terms of runtime. 

## Blockers:

- [X] Implement workers argument for number of threads to use
- [X] Check if file is saved
- [X] Use report for the output
- [X] Add vanilla flow in case of a single worker
- [X] Add gf180mcu.drc documentation for options
- [ ] Add gf180mcu.drc help menu?
- [ ] Add parallel_rule_checker.rb documentation?
- [ ] Test the merging of reports properly
- [ ] Add cancel functionality