### PR TITLE
fix: dont pre-merge holes when getting the area

### DIFF
--- a/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/nplus.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/nplus.drc
@@ -219,7 +219,7 @@ if FEOL
 
   # Rule NP.8b: Minimum area enclosed by Nplus (um2). is 0.35µm²
   logger.info('Executing rule NP.8b')
-  np8b_l1 = nplus.holes.with_area(nil, 0.35.um)
+  np8b_l1 = nplus.holes.raw.with_area(nil, 0.35.um)
   np8b_l1.output('NP.8b', 'NP.8b : Minimum area enclosed by Nplus (um2). : 0.35µm²')
   np8b_l1.forget
 

--- a/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/pplus.drc
+++ b/gf180mcuD/libs.tech/klayout/tech/drc/rule_decks/pplus.drc
@@ -218,7 +218,7 @@ if FEOL
 
   # Rule PP.8b: Minimum area enclosed by Pplus (um2). is 0.35µm²
   logger.info('Executing rule PP.8b')
-  pp8b_l1 = pplus.holes.with_area(nil, 0.35.um)
+  pp8b_l1 = pplus.holes.raw.with_area(nil, 0.35.um)
   pp8b_l1.output('PP.8b', 'PP.8b : Minimum area enclosed by Pplus (um2). : 0.35µm²')
   pp8b_l1.forget
 


### PR DESCRIPTION
This is an issue when there's a p/n-plus ring around a p/n-plus area with a hole: the hole of the ring gets merged with the inner hole.

Another solution would be to subtract p/n-plus from the holes. However this is less performant.